### PR TITLE
Make query parameters available on get requests for all resources

### DIFF
--- a/src/contacts/Contacts.php
+++ b/src/contacts/Contacts.php
@@ -209,13 +209,16 @@ class Contacts extends Resource
     /**
      * List all custom fields
      * @see https://developers.activecampaign.com/v3/reference#retrieve-fields-1
+     * @param array $query_params
      * @return string
      */
-    public function listAllCustomFields()
+    public function listAllCustomFields(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('/api/3/fields');
+            ->get('/api/3/fields', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }

--- a/src/deals/Deals.php
+++ b/src/deals/Deals.php
@@ -190,13 +190,16 @@ class Deals extends Resource
     /**
      * List all custom fields
      * @see https://developers.activecampaign.com/reference#retrieve-all-dealcustomfielddata-resources
+     * @param array $query_params
      * @return string
      */
-    public function listAllCustomFields()
+    public function listAllCustomFields(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('/api/3/dealCustomFieldMeta');
+            ->get('/api/3/dealCustomFieldMeta', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }
@@ -221,13 +224,16 @@ class Deals extends Resource
     /**
      * List all pipelines
      * @see https://developers.activecampaign.com/reference#list-all-pipelines
+     * @param array $query_params
      * @return string
      */
-    public function listAllPipelines()
+    public function listAllPipelines(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('/api/3/dealGroups');
+            ->get('/api/3/dealGroups', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }
@@ -235,13 +241,16 @@ class Deals extends Resource
     /**
      * List all stages
      * @see https://developers.activecampaign.com/reference#list-all-deal-stages
+     * @param array $query_params
      * @return string
      */
-    public function listAllStages()
+    public function listAllStages(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('/api/3/dealStages');
+            ->get('/api/3/dealStages', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }

--- a/src/lists/Lists.php
+++ b/src/lists/Lists.php
@@ -36,9 +36,10 @@ class Lists extends Resource
      * Retrieve all lists or a list when id is not null
      * @see https://developers.activecampaign.com/reference#retrieve-a-list
      * @param null $id
+     * @param array $query_params
      * @return string
      */
-    public function retrieve($id = null)
+    public function retrieve($id = null, array $query_params = [])
     {
         $uri = '/api/3/lists';
         if (!is_null($id)) {
@@ -46,7 +47,9 @@ class Lists extends Resource
         }
         $req = $this->client
             ->getClient()
-            ->get($uri);
+            ->get($uri,  [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }

--- a/src/tags/Tags.php
+++ b/src/tags/Tags.php
@@ -15,13 +15,16 @@ class Tags extends Resource
     /**
      * List all tags
      * @see https://developers.activecampaign.com/reference#retrieve-all-tags
+     * @param array $query_params
      * @return string
      */
-    public function listAll()
+    public function listAll(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('/api/3/tags');
+            ->get('/api/3/tags', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }

--- a/src/tracking/EventTracking.php
+++ b/src/tracking/EventTracking.php
@@ -67,13 +67,16 @@ class EventTracking extends Resource
      * List all events
      * @see https://developers.activecampaign.com/v3/reference#list-all-event-types
      *
+     * @param array $query_params
      * @return string
      */
-    public function listAllEvents()
+    public function listAllEvents(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('api/3/eventTrackingEvents');
+            ->get('api/3/eventTrackingEvents', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }

--- a/src/tracking/SiteTracking.php
+++ b/src/tracking/SiteTracking.php
@@ -15,13 +15,16 @@ class SiteTracking extends Resource
     /**
      * Get site tracking status (enabled or disabled)
      * @see https://developers.activecampaign.com/reference#retrieve-site-tracking-status
+     * @param array $query_params
      * @return string
      */
-    public function retrieveStatus()
+    public function retrieveStatus(array $query_params = [])
     {
         $req = $this->client
             ->getClient()
-            ->get('api/3/siteTracking');
+            ->get('api/3/siteTracking', [
+                'query' => $query_params
+            ]);
 
         return $req->getBody()->getContents();
     }


### PR DESCRIPTION
Though not documented by ActiveCampaign per resource, it limits the responses by default as explained here: https://developers.activecampaign.com/reference#section-pagination

Adding query parameters to the get requests allows us to access the complete data. 🔥